### PR TITLE
🎣 Adds eslint-plugin-react-hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ yarn add -D \
     eslint-plugin-jest \
     eslint-plugin-jsx-a11y \
     eslint-plugin-promise \
-    eslint-plugin-react
+    eslint-plugin-react \
+    eslint-plugin-react-hooks
 ```
 
 
@@ -72,7 +73,8 @@ If there are plugins or rules which you do not want to use, you'll have to opt-i
         "7geese/rules/jest/on",
         "7geese/rules/jsx-a11y/off",
         "7geese/rules/promise/on",
-        "7geese/rules/react/off"
+        "7geese/rules/react/off",
+        "7geese/rules/react-hooks/off"
     ]
 }
 ```

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-jsx-a11y": "6.2.1",
     "eslint-plugin-promise": "4.0.1",
     "eslint-plugin-react": "7.12.4",
+    "eslint-plugin-react-hooks": "1.0.1",
     "np": "4.0.2"
   },
   "peerDependencies": {
@@ -37,7 +38,8 @@
     "eslint-plugin-jest": "^22.2.2",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-promise": "^4.0.1",
-    "eslint-plugin-react": "^7.12.4"
+    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-react-hooks": "^1.0.1"
   },
   "repository": {
     "type": "git",

--- a/rules/react-hooks/off.js
+++ b/rules/react-hooks/off.js
@@ -1,0 +1,5 @@
+module.exports = {
+    rules: {
+        'react-hooks/rules-of-hooks': 'off',
+    },
+};

--- a/rules/react-hooks/on.js
+++ b/rules/react-hooks/on.js
@@ -1,0 +1,6 @@
+module.exports = {
+    plugins: ['react-hooks'],
+    rules: {
+        'react-hooks/rules-of-hooks': 'error',
+    },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -831,6 +831,11 @@ eslint-plugin-promise@4.0.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz#2d074b653f35a23d1ba89d8e976a985117d1c6a2"
   integrity sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==
 
+eslint-plugin-react-hooks@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.0.1.tgz#76b6fb4edafab02eab0090078977687157605dd9"
+  integrity sha512-yNhvY7EFBp0mq0Bt8BHoS57GwJ4e1qSYdvDFSfPnjmiSmyGUfQFQGcQs4K0JQFDGopWkURWq58psbUJIhWZ2Kg==
+
 eslint-plugin-react@7.12.4:
   version "7.12.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"


### PR DESCRIPTION
Adds the [`eslint-plugin-react-hooks`](https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks) plugin.

This will require that we cut a new major version, according to our [release guidelines](https://github.com/7Geese/eslint-config-7geese/blob/master/.github/RELEASING.md). As a result, I will cut a pre-release version now, and then when the [new React version has landed](https://github.com/7Geese/7Geese/pull/10897) in our codebase, we'll actually merge this and do a proper major release.