### PR TITLE
jest/no-unfocused-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 *yarn-error.log
 
 *old-config
+.idea/

--- a/rules/jest/on.js
+++ b/rules/jest/on.js
@@ -15,7 +15,7 @@ module.exports = {
         'jest/no-disabled-tests': 'error',
         //  Error out if set to only run a single test
         //  https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-focused-tests.md
-        'jest/no-focused-tests': 'off',
+        'jest/no-focused-tests': 'error',
         //  https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-hooks.md
         'jest/no-hooks': 'off',
         //  https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-identical-title.md


### PR DESCRIPTION
We should probably have this turned on. I found a case of `it.only` being accidentally used in a file. This caused us to skip 9 tests. Let's make sure we're not committing this by accident again